### PR TITLE
Update module name and import paths to fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Usage
 
 ```go
-import "rogchap.com/v8go"
+import "github.com/robfig/v8go"
 ```
 
 ### Running a script

--- a/context_test.go
+++ b/context_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"testing"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestContextRunScript(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestErrorFormatting(t *testing.T) {

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestFunctionTemplate(t *testing.T) {

--- a/function_test.go
+++ b/function_test.go
@@ -7,7 +7,7 @@ package v8go_test
 import (
 	"testing"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestFunctionCall(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module rogchap.com/v8go
+module github.com/robfig/v8go
 
 go 1.12

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestIsolateTermination(t *testing.T) {

--- a/json_test.go
+++ b/json_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestJSONParse(t *testing.T) {

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -8,7 +8,7 @@ import (
 	"math/big"
 	"testing"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestObjectTemplate(t *testing.T) {

--- a/object_test.go
+++ b/object_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestObjectSet(t *testing.T) {

--- a/promise_test.go
+++ b/promise_test.go
@@ -7,7 +7,7 @@ package v8go_test
 import (
 	"testing"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestPromise(t *testing.T) {

--- a/v8go_test.go
+++ b/v8go_test.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"testing"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestVersion(t *testing.T) {

--- a/value_test.go
+++ b/value_test.go
@@ -13,7 +13,7 @@ import (
 	"runtime"
 	"testing"
 
-	"rogchap.com/v8go"
+	"github.com/robfig/v8go"
 )
 
 func TestValueNewBaseCases(t *testing.T) {


### PR DESCRIPTION
This is necessary for this module to be importable in both legacy and module-aware modes.